### PR TITLE
Fix image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
@@ -237,7 +237,7 @@
             Software Libre
           </h1>
           <img
-            src="/assets/images/logo_full_white.webp"
+            src="assets/images/logo_full_white.webp"
             alt="FLISol Guayaquil"
             class="w-100 w-xxl-75 px-xxl-8"
           />


### PR DESCRIPTION
Bug: https://flisolgye-2025.github.io/web/

La página en github pages muestra este error
<img width="486" alt="Screenshot 2025-04-29 at 7 57 10 PM" src="https://github.com/user-attachments/assets/2a6b357a-ea01-40fa-afc6-bca05f9c6599" />

Esta PR arregla el typo en la path de la imagen
